### PR TITLE
[enh] Add Whaleslide as a autocomplete backend

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -92,6 +92,12 @@ def swisscows(query, lang):
     resp = loads(get(url.format(query=urlencode({'query': query}))).text)
     return resp
 
+def whaleslide(query, lang):
+    # whaleslide autocompleter
+    url = 'https://search.whaleslide.com/api/v1/suggestions/get?{query}&num=5'
+
+    resp = loads(get(url.format(query=urlencode({'q': query}))).text)
+    return resp
 
 def qwant(query, lang):
     # qwant autocompleter (additional parameter : lang=en_en&count=xxx )
@@ -125,6 +131,7 @@ backends = {'dbpedia': dbpedia,
             'google': google,
             'startpage': startpage,
             'swisscows': swisscows,
+            'whaleslide': whaleslide
             'qwant': qwant,
             'wikipedia': wikipedia
             }


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This adds the Autocomplete feature of Whaleslide.com engine.

<!-- explain the changes in your PR, algorithms, design, architecture -->
Similiar to other autocomplete engines, no changes.

## Why is this change important?

More option to choose from.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

Make searX better.
## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

Go to settings and change the autocomplete option to "Whaleslide".
## Author's checklist

<!-- additional notes for reviewiers -->
N/A

## Related issues
https://github.com/searx/searx/issues/191
"Intellegent autocompleter"

<!--
Closes #234
-->
