### PR TITLE
[enh] Add Petalsearch as a autocomplete backend

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -115,6 +115,19 @@ def qwant(query, lang):
 
     return results
 
+def petalsearch(query, lang):
+    # petalsearch autocompleter
+    url = 'https://petalsearch.com/sugg_search?{query}'
+
+    resp = get(url.format(query=urlencode({'query': query, 'lang': lang})))
+    results = []
+
+    if resp.ok:
+        data = loads(resp.text)
+        for item in data["sug_list"]:
+            results.append(item["name"])
+
+    return results
 
 def wikipedia(query, lang):
     # wikipedia autocompleter
@@ -133,6 +146,7 @@ backends = {'dbpedia': dbpedia,
             'swisscows': swisscows,
             'whaleslide': whaleslide,
             'qwant': qwant,
+            'petalsearch': petalsearch,
             'wikipedia': wikipedia
             }
 


### PR DESCRIPTION
"https://petalsearch.com/sugg_search?query=why+is"

## What does this PR do?

<!-- MANDATORY -->

This adds the Autocomplete feature of Petalsearch.com engine.

<!-- explain the changes in your PR, algorithms, design, architecture -->
Similiar to other autocomplete engines, no changes.

## Why is this change important?

More option to choose from.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

Make searX better.
## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

Go to settings and change the autocomplete option to "Petalsearch".
## Author's checklist

<!-- additional notes for reviewiers -->
N/A

## Related issues
https://github.com/searx/searx/issues/191
"Intellegent autocompleter"

<!--
Closes #234
-->
