### PR TITLE
[enh] Add Millionshort as a autocomplete backend

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -99,6 +99,21 @@ def whaleslide(query, lang):
     resp = loads(get(url.format(query=urlencode({'q': query}))).text)
     return resp
 
+def millionshort(query, lang):
+    # millionshort autocompleter
+    url = 'https://millionshort.com/api/suggestions?{query}'
+
+    resp = get(url.format(query=urlencode({'q': query, 'lang': lang})))
+
+    results = []
+
+    if resp.ok:
+        data = loads(resp.text)
+        for item in data['suggestions']:
+                results.append(item)
+
+    return results
+
 def qwant(query, lang):
     # qwant autocompleter (additional parameter : lang=en_en&count=xxx )
     url = 'https://api.qwant.com/api/suggest?{query}'
@@ -145,6 +160,7 @@ backends = {'dbpedia': dbpedia,
             'startpage': startpage,
             'swisscows': swisscows,
             'whaleslide': whaleslide,
+            'millionshort': millionshort,
             'qwant': qwant,
             'petalsearch': petalsearch,
             'wikipedia': wikipedia


### PR DESCRIPTION
Example of a query returning JSON data:

https://millionshort.com/api/suggestions?q=best+thing

## What does this PR do?

<!-- MANDATORY -->

This adds the Autocomplete feature of Petalsearch.com engine.

<!-- explain the changes in your PR, algorithms, design, architecture -->
Similiar to other autocomplete engines, no changes.

## Why is this change important?

More option to choose from.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

Make searX better.
## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

Go to settings and change the autocomplete option to "Millionshort".
## Author's checklist

<!-- additional notes for reviewiers -->
N/A

## Related issues
https://github.com/searx/searx/issues/191
"Intellegent autocompleter"

<!--
Closes #234
-->
