### PR TITLE
[enh] Add Junior Search Engine "blinde-kuh.de"

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1367,6 +1367,25 @@ engines:
       require_api_key: false
       results: html
 
+- name : blindekuh
+    shortcut: bkuh
+    engine: xpath
+    timeout : 4.0
+    paging : True
+    search_url : https://www.blinde-kuh.de/bksearch.cgi?smart=0&query={query}&page={pageno}
+    url_xpath : //a[@class="bkentry_url"]/abbr
+    title_xpath : //h2[@class="bkentry_title"]
+    content_xpath : //p[@class="bkentry_description"]
+    first_page_num : 1
+    page_size : 10
+    disabled : True
+    about:
+      website: https://www.blinde-kuh.de
+      wikidata_id: Q884201
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
   - name : naver
     shortcut: nvr
     engine: xpath


### PR DESCRIPTION
Upstream example:
https://www.blinde-kuh.de/bksearch.cgi?smart=0&sid=&query=musik


## What does this PR do?

This adds blinde-kuh.de as another optional engine.
It is a junior German search engine for u14.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Added blinde-kuh.de using the ``` xpath ``` engine.

## Why is this change important?

More engines to choose from.
First enngine for u14.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Make Searx better, more privacy for end-users.

## How to test this PR locally?

Do a search with:
``` !bkuh musik```

## Author's checklist
Maybe some searches like "pizza" are not always Paginated.

<!-- additional notes for reviewiers -->

## Related issues
N/A