### PR TITLE
[enh] Add Product metaseach-engine Geizhals.de

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -439,6 +439,28 @@ engines:
 #    disabled : True
 #    timeout: 5
 
+  - name : geizhals
+    shortcut : geizhals
+    engine : xpath
+    category : general
+    timeout : 5.0
+    paging : True
+    # Curently not optimised
+    page_size : 29
+    # Locale Parameters could be "hloc=at" or "hloc=de"
+    # For Price low-to-high "sort=p" is used, high-to-low "sort=-p" 
+    search_url : https://geizhals.de/?fs={query}&hloc=de&sort=p&pg={pageno}#productlist
+    title_xpath : //a[@class="listview__name-link"]
+    url_xpath : //a[@class="listview__name-link"]/@href
+    content_xpath : //span[@class="price"]
+    disabled : True
+    about:
+      website: https://geizhals.de  
+      wikidata_id: Q15977657
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
   - name : 1x
     engine : www1x
     shortcut : 1x


### PR DESCRIPTION
Upstream example:
https://geizhals.de/?fs=1TB+HDD&hloc=at&hloc=de&in=&sort=p

## What does this PR do?

This adds geizhals.de as another optional engine.
A site to look for Product deal/dealers.
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Added geizhals.de using the ``` xpath ``` engine.

## Why is this change important?

More shopping engines aside from ebay to choose from.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Make Searx better.

## How to test this PR locally?

Do a search with:
``` !geizhals 1TB HDD```

## Author's checklist
Pagination for some queries doesn't always work

<!-- additional notes for reviewiers -->

## Related issues
N/A