### PR TITLE
[enh] Add e-comm site Reichelt.de

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -461,6 +461,26 @@ engines:
       require_api_key: false
       results: HTML
 
+  - name : reichelt
+    shortcut : rei 
+    engine : xpath
+    category : general
+    timeout : 11.0
+    # Sometime slow and no pagination - better manipulate the params
+    paging : False
+    page_size : 16
+    search_url : https://www.reichelt.de/index.html?ACTION=446&LA=446&nbc=1&q={query}&SID=929b474904847bc849ea8d4bc040290a3b22d1575866724688284 
+    title_xpath : //a[@class="notranslate"]/@title
+    url_xpath : //a[@class="notranslate"]/@href
+    content_xpath : //p[@class="availability"]/span
+    disabled : True
+    about:
+      website: https://reichelt.de
+      wikidata_id: Q1598978
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
   - name : 1x
     engine : www1x
     shortcut : 1x


### PR DESCRIPTION
Upstream example:
[https://www.reichelt.de/index.html?ACTION=446&LA=0&nbc=1&q=toshiba](https://www.reichelt.de/index.html?ACTION=446&LA=0&nbc=1&q=toshiba)

## What does this PR do?

This adds reichelt.de as another optional engine.
More than 120.000 Products.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Added reichelt.de using the ``` xpath ``` engine.

## Why is this change important?

More shopping engines aside from ebay to choose from.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Make Searx better.

## How to test this PR locally?

Do a search with:
``` !reichelt 1TB HDD```

## Author's checklist
Better manipulate parameters to have pagination.

<!-- additional notes for reviewiers -->

## Related issues
N/A